### PR TITLE
Improved parameterization

### DIFF
--- a/vmware-puppetdb-trueup/compare-vmware-to-puppetdb.ps1
+++ b/vmware-puppetdb-trueup/compare-vmware-to-puppetdb.ps1
@@ -4,7 +4,7 @@ param (
     [SecureString]$VMwarePassword,
     [String]$VMwareCluster = 'operations2',
     [String]$PuppetServer = 'https://puppet.ops.puppetlabs.net',
-    [String]$Token = $(Get-Content -Path "$HOME/.puppetlabs/token" -ErrorAction SilentlyContinue),
+    [String]$Token = $(Get-Content -Path "$HOME/.puppetlabs/token" -ErrorAction SilentlyContinue)
 )
 
 if ($PuppetServer -match 'https://') {

--- a/vmware-puppetdb-trueup/compare-vmware-to-puppetdb.ps1
+++ b/vmware-puppetdb-trueup/compare-vmware-to-puppetdb.ps1
@@ -17,7 +17,7 @@ if ($PuppetServer -match 'https://') {
 $pdb_api = "${PuppetServer}:${port}/pdb/query/v4"
 
 $headers = @{
-    'Content-Type'     = 'application/json'
+    'Content-Type' = 'application/json'
 }
 if ($Token) {
     $headers += @{'X-Authentication' = ${Token}}

--- a/vmware-puppetdb-trueup/compare-vmware-to-puppetdb.ps1
+++ b/vmware-puppetdb-trueup/compare-vmware-to-puppetdb.ps1
@@ -9,7 +9,7 @@ param (
 
 if ($PuppetServer -match 'https://') {
     $port = 8081
-    $SkipCertificateCheck = true
+    $SkipCertificateCheck = $true
 } else {
     $port = 8080
     $SkipCertificateCheck = false

--- a/vmware-puppetdb-trueup/compare-vmware-to-puppetdb.ps1
+++ b/vmware-puppetdb-trueup/compare-vmware-to-puppetdb.ps1
@@ -12,7 +12,7 @@ if ($PuppetServer -match 'https://') {
     $SkipCertificateCheck = $true
 } else {
     $port = 8080
-    $SkipCertificateCheck = false
+    $SkipCertificateCheck = $false
 }
 $pdb_api = "${PuppetServer}:${port}/pdb/query/v4"
 


### PR DESCRIPTION
Support http and https puppetdb URLs
Not all setups require a token, skip the header when not present
When user/pass are not both provided, interactively prompt for them